### PR TITLE
Fix memory leak in dwc_xdci_core_init when core_handle is NULL

### DIFF
--- a/drivers/dw3/XdciDWC.c
+++ b/drivers/dw3/XdciDWC.c
@@ -1358,11 +1358,11 @@ dwc_xdci_core_init (
 	UINT32                          max_delay_iter = DWC_XDCI_MAX_DELAY_ITERATIONS;
 	UINT8                           i;
 
-	local_core_handle = (XDCI_CORE_HANDLE *)calloc (1, sizeof(XDCI_CORE_HANDLE));
-
 	if (core_handle == NULL) {
 	        return EFI_INVALID_PARAMETER;
 	}
+
+	local_core_handle = (XDCI_CORE_HANDLE *)calloc (1, sizeof(XDCI_CORE_HANDLE));
 
 	if (local_core_handle == NULL) {
 	        DEBUG ((DEBUG_INFO, "dwc_xdci_core_init: Failed to allocate handle for xDCI\n"));


### PR DESCRIPTION
If core_handle is NULL then the error exit path leaks the previous
allocation of local_core_handle causing a memory leak. Instead,
move the null check on core_handle to before the memory allocation
to avoid this leak.

Signed-off-by: Colin Ian King <colin.king@canonical.com>